### PR TITLE
Update versions.tf to support later versions of Terraform than 0.12

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0"
 }


### PR DESCRIPTION
Hi

I've been using this module with terraform-aws-lightsail module which i've also forked, both of them work fine (so far) in terraform 0.14

terraform version
Terraform v0.14.7
+ provider registry.terraform.io/hashicorp/aws v3.30.0

Updating the versions.tf to make support MINIMUM of 0.12 instead of just 0.12